### PR TITLE
Remove pybind deps from importer and annotator

### DIFF
--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/CMakeLists.txt
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(TorchMLIRJITIRImporter MODULE
   node_importer.cpp
   ivalue_importer.cpp
   init_python_bindings.cpp
+  pybind.cpp
   torch_to_mlir_utils.cpp
   )
 

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/class_annotator.h
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/class_annotator.h
@@ -25,8 +25,6 @@
 
 #include <torch/csrc/jit/ir/ir.h>
 
-#include "pybind.h"
-
 namespace torch_mlir {
 
 // An annotation on a class's attribute (corresponds to a c10::ClassAttribute).
@@ -162,7 +160,8 @@ public:
   // These will be put into an `ArgAnnotation` struct -- see there for
   // precise definitions of the promised semantics of each entry.
   void annotateArgs(c10::ClassType &rootClassType,
-                    std::vector<std::string> path, py::list argAnnotations);
+                    std::vector<std::string> path,
+                    std::vector<ArgAnnotation> argAnnotations);
 
   // The annotations collected so far.
   const ClassAnnotationMap &getAnnotationMap();
@@ -191,8 +190,6 @@ private:
   std::unordered_map<torch::jit::Function *, MethodAnnotation *>
       functionToMethodMap;
 };
-
-void initClassAnnotatorBindings(py::module &m);
 
 } // namespace torch_mlir
 

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/function_importer.cpp
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/function_importer.cpp
@@ -18,7 +18,6 @@
 #include "mlir-c/BuiltinTypes.h"
 #include "mlir-c/Diagnostics.h"
 
-namespace py = pybind11;
 using namespace torch_mlir;
 
 MlirOperation torch_mlir::importJitFunctionAsFuncOp(

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/function_importer.h
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/function_importer.h
@@ -13,7 +13,6 @@
 #include <memory>
 
 #include "node_importer.h"
-#include "pybind.h"
 
 #include "mlir-c/IR.h"
 

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/get_registered_ops.h
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/get_registered_ops.h
@@ -16,6 +16,7 @@
 #define TORCHMLIRJITIRIMPORTER_CSRC_GETREGISTEREDOPS_H
 
 #include "pybind.h"
+#include <torch/csrc/utils/pybind.h>
 
 namespace torch_mlir {
 

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/init_python_bindings.cpp
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/init_python_bindings.cpp
@@ -11,9 +11,9 @@
 
 #include <ATen/core/dispatch/Dispatcher.h>
 
-#include "class_annotator.h"
 #include "get_registered_ops.h"
 #include "module_builder.h"
+#include "pybind.h"
 
 using namespace torch_mlir;
 

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/ivalue_importer.h
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/ivalue_importer.h
@@ -13,7 +13,6 @@
 #include <memory>
 
 #include "class_annotator.h"
-#include "pybind.h"
 
 #include "mlir-c/IR.h"
 

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/node_importer.cpp
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/node_importer.cpp
@@ -22,7 +22,6 @@
 #include "torch-mlir-c/TorchOps.h"
 #include "torch-mlir-c/TorchTypes.h"
 
-namespace py = pybind11;
 using namespace torch_mlir;
 
 using Value = torch::jit::Value;

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/node_importer.h
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/node_importer.h
@@ -12,8 +12,6 @@
 
 #include <memory>
 
-#include "pybind.h"
-
 #include "mlir-c/IR.h"
 
 #include <torch/csrc/jit/api/compilation_unit.h>

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/pybind.cpp
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/pybind.cpp
@@ -1,0 +1,63 @@
+//===- pybind.cpp ------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#include "pybind.h"
+#include "class_annotator.h"
+
+#include <torch/csrc/Dtype.h>
+#include <torch/csrc/utils/pybind.h>
+
+using namespace torch_mlir;
+
+static c10::ScalarType convertToC10ScalarType(py::object obj) {
+  if (THPDtype_Check(obj.ptr())) {
+    // Need reinterpret_cast, since no C++-level inheritance is involved.
+    THPDtype *dtype = reinterpret_cast<THPDtype *>(obj.ptr());
+    return dtype->scalar_type;
+  }
+  std::stringstream ss;
+  ss << "unsupported scalar type '" << obj << "'";
+  throw std::invalid_argument(ss.str());
+}
+
+static std::vector<ArgAnnotation> getArgAnnotations(py::list pyArgAnnotations) {
+  std::vector<ArgAnnotation> argAnnotations(pyArgAnnotations.size());
+  for (int i = 0, e = argAnnotations.size(); i != e; i++) {
+    if (pyArgAnnotations[i].is_none()) {
+      continue;
+    }
+    auto tuple = py::cast<py::tuple>(pyArgAnnotations[i]);
+    auto shape = tuple[0];
+    auto dtype = tuple[1];
+    auto hasValueSemantics = tuple[2];
+    if (!shape.is_none()) {
+      argAnnotations[i].shape = py::cast<std::vector<int64_t>>(shape);
+    }
+    if (!dtype.is_none()) {
+      argAnnotations[i].dtype = convertToC10ScalarType(dtype);
+    }
+    argAnnotations[i].hasValueSemantics = py::cast<bool>(hasValueSemantics);
+  };
+
+  return argAnnotations;
+}
+
+void torch_mlir::initClassAnnotatorBindings(py::module &m) {
+  py::class_<ClassAnnotator>(m, "ClassAnnotator")
+      .def(py::init<>())
+      .def("exportPath", &ClassAnnotator::exportPath)
+      .def("exportNone", &ClassAnnotator::exportNone)
+      .def("annotateArgs",
+           [&](ClassAnnotator &cls_annotator, c10::ClassType &rootClassType,
+               std::vector<std::string> path, py::list argAnnotations) {
+             cls_annotator.annotateArgs(rootClassType, path,
+                                        getArgAnnotations(argAnnotations));
+           })
+      .def("__repr__", &ClassAnnotator::toString);
+}

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/pybind.h
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/pybind.h
@@ -16,15 +16,9 @@
 
 #include <torch/csrc/utils/pybind.h>
 
+namespace py = pybind11;
 namespace torch_mlir {
-
-/// Thrown on failure when details are in MLIR emitted diagnostics.
-class mlir_diagnostic_emitted : public std::runtime_error {
-public:
-  mlir_diagnostic_emitted(const char *what) : std::runtime_error(what) {}
-  mlir_diagnostic_emitted() : std::runtime_error("see diagnostics") {}
-};
-
+void initClassAnnotatorBindings(py::module &m);
 } // namespace torch_mlir
 
 #endif // TORCHMLIRJITIRIMPORTER_CSRC_PYBIND_H

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/torch_to_mlir_utils.h
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/torch_to_mlir_utils.h
@@ -12,8 +12,6 @@
 
 #include <memory>
 
-#include "pybind.h"
-
 #include "mlir-c/IR.h"
 
 #include <torch/csrc/jit/api/compilation_unit.h>
@@ -21,6 +19,13 @@
 #include <torch/csrc/jit/ir/ir.h>
 
 namespace torch_mlir {
+
+/// Thrown on failure when details are in MLIR emitted diagnostics.
+class mlir_diagnostic_emitted : public std::runtime_error {
+public:
+  mlir_diagnostic_emitted(const char *what) : std::runtime_error(what) {}
+  mlir_diagnostic_emitted() : std::runtime_error("see diagnostics") {}
+};
 
 /// Gets a corresponding MlirType for the Torch ScalarType.
 /// `c10::`ScalarType` is used to represent tensor dtypes, and is a different


### PR DESCRIPTION
I want to use the torch dialect importer from C++. However, the importer and annotator have inclusion usage of pybind and python. In this pull request, I refactor to remove pybind dependencies from importer and annotators' C++ sources.